### PR TITLE
Add QoS parameter to Image topics

### DIFF
--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -103,6 +103,9 @@ class MultiSubscriber:
         if topic_type is not None and topic_type != msg_type_string:
             raise TypeConflictException(topic, topic_type, msg_type_string)
 
+        # If True: set topic QoS of type `Image` to `qos_profile_sensor_data`
+        self.image_qos_sensor_data = node_handle.get_parameter('image_qos_sensor_data').value
+
         # Certain combinations of publisher and subscriber QoS parameters are
         # incompatible. Here we make a "best effort" attempt to match existing
         # publishers for the requested topic. This is not perfect because more
@@ -116,7 +119,7 @@ class MultiSubscriber:
             reliability=ReliabilityPolicy.RELIABLE,
         )
 
-        if msg_type_string == "sensor_msgs/msg/Image":
+        if msg_type_string == "sensor_msgs/msg/Image" and self.image_qos_sensor_data:
             qos = qos_profile_sensor_data
         else:
             infos = node_handle.get_publishers_info_by_topic(topic)

--- a/rosbridge_library/src/rosbridge_library/internal/subscribers.py
+++ b/rosbridge_library/src/rosbridge_library/internal/subscribers.py
@@ -35,6 +35,7 @@ from threading import Lock, RLock
 
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
+from rclpy.qos import qos_profile_sensor_data
 from rosbridge_library.internal import ros_loader
 from rosbridge_library.internal.message_conversion import msg_class_type_repr
 from rosbridge_library.internal.outgoing_message import OutgoingMessage
@@ -115,11 +116,14 @@ class MultiSubscriber:
             reliability=ReliabilityPolicy.RELIABLE,
         )
 
-        infos = node_handle.get_publishers_info_by_topic(topic)
-        if any(pub.qos_profile.durability == DurabilityPolicy.TRANSIENT_LOCAL for pub in infos):
-            qos.durability = DurabilityPolicy.TRANSIENT_LOCAL
-        if any(pub.qos_profile.reliability == ReliabilityPolicy.BEST_EFFORT for pub in infos):
-            qos.reliability = ReliabilityPolicy.BEST_EFFORT
+        if msg_type_string == "sensor_msgs/msg/Image":
+            qos = qos_profile_sensor_data
+        else:
+            infos = node_handle.get_publishers_info_by_topic(topic)
+            if any(pub.qos_profile.durability == DurabilityPolicy.TRANSIENT_LOCAL for pub in infos):
+                qos.durability = DurabilityPolicy.TRANSIENT_LOCAL
+            if any(pub.qos_profile.reliability == ReliabilityPolicy.BEST_EFFORT for pub in infos):
+                qos.reliability = ReliabilityPolicy.BEST_EFFORT
 
         # Create the subscriber and associated member variables
         # Subscriptions is initialized with the current client to start with.

--- a/rosbridge_server/launch/rosbridge_websocket_launch.xml
+++ b/rosbridge_server/launch/rosbridge_websocket_launch.xml
@@ -12,13 +12,15 @@
   <arg name="max_message_size" default="10000000" />
   <arg name="unregister_timeout" default="10.0" />
 
-  <arg name="use_compression" default="false" />
+  <arg name="use_compression" default="true" />
   <arg name="call_services_in_new_thread" default="false" />
 
   <arg name="topics_glob" default="" />
   <arg name="services_glob" default="" />
   <arg name="params_glob" default="" />
   <arg name="bson_only_mode" default="false" />
+
+  <arg name="image_qos_sensor_data" default="true" />
 
   <arg unless="$(var bson_only_mode)" name="binary_encoder" default="default"/>
 
@@ -58,6 +60,8 @@
       <param name="params_glob" value="$(var params_glob)"/>
 
       <param name="bson_only_mode" value="$(var bson_only_mode)"/>
+
+      <param name="image_qos_sensor_data" value="$(var image_qos_sensor_data)"/>
     </node>
   </group>
 

--- a/rosbridge_server/scripts/rosbridge_websocket.py
+++ b/rosbridge_server/scripts/rosbridge_websocket.py
@@ -197,6 +197,8 @@ class RosbridgeWebsocketNode(Node):
 
         bson_only_mode = self.declare_parameter("bson_only_mode", False).value
 
+        self.declare_parameter("image_qos_sensor_data", True).value
+
         RosbridgeWebSocket.client_manager = ClientManager(self)
 
         # Publisher for number of connected clients


### PR DESCRIPTION
#### **Overview**

- Add QoS parameter to switch between qos_profile_sensor_data or default qos type in `Image` topics. The 'sensor data' profile set the QoS to best_effort, which in our test seems to perform better.

- This package is not in autoproj yet. A PR for this will be created soon.

#### **What was added/changed in this update**

- [Update QoS profile for Image msgs from ROS2](https://github.com/Brazilian-Institute-of-Robotics/rosbridge_suite/commit/ce2f40150e82b46faaa1e580ebc8a274c82d6160)
- [Creating a variable to define the QoS type of Image type topics](https://github.com/Brazilian-Institute-of-Robotics/rosbridge_suite/commit/0522848cb74408417961c62a4e401778deffc600)

#### **Depends On:**

- N/A

#### **Related Issues:**

- N/A

#### **Notes:**

- N/A